### PR TITLE
#8 support env variables

### DIFF
--- a/4/bin/entrypoint.sh
+++ b/4/bin/entrypoint.sh
@@ -2,5 +2,17 @@
 
 set -euo pipefail
 
+declare -a args
+
+add_env_var_as_env_prop() {
+  if [ ! -z "$1" ]; then
+    args+=("-D$2=$1")
+  fi
+}
+
+add_env_var_as_env_prop "${SONAR_LOGIN:-}" "sonar.login"
+add_env_var_as_env_prop "${SONAR_PASSWORD:-}" "sonar.password"
+
 export SONAR_USER_HOME="$PWD/.sonar"
-sonar-scanner
+
+sonar-scanner "${args[@]}"

--- a/4/bin/entrypoint.sh
+++ b/4/bin/entrypoint.sh
@@ -5,7 +5,7 @@ set -euo pipefail
 declare -a args
 
 add_env_var_as_env_prop() {
-  if [ ! -z "$1" ]; then
+  if [ "$1" ]; then
     args+=("-D$2=$1")
   fi
 }
@@ -13,7 +13,13 @@ add_env_var_as_env_prop() {
 add_env_var_as_env_prop "${SONAR_LOGIN:-}" "sonar.login"
 add_env_var_as_env_prop "${SONAR_PASSWORD:-}" "sonar.password"
 add_env_var_as_env_prop "${SONAR_USER_HOME:-}" "sonar.userHome"
+add_env_var_as_env_prop "${SONAR_PROJECT_BASE_DIR:-}" "sonar.projectBaseDir"
 
-export SONAR_USER_HOME="$PWD/.sonar"
+PROJECT_BASE_DIR="$PWD"
+if [ "${SONAR_PROJECT_BASE_DIR:-}" ]; then
+  PROJECT_BASE_DIR="${SONAR_PROJECT_BASE_DIR}"
+fi
 
+export SONAR_USER_HOME="$PROJECT_BASE_DIR/.sonar"
 sonar-scanner "${args[@]}"
+

--- a/4/bin/entrypoint.sh
+++ b/4/bin/entrypoint.sh
@@ -12,6 +12,7 @@ add_env_var_as_env_prop() {
 
 add_env_var_as_env_prop "${SONAR_LOGIN:-}" "sonar.login"
 add_env_var_as_env_prop "${SONAR_PASSWORD:-}" "sonar.password"
+add_env_var_as_env_prop "${SONAR_USER_HOME:-}" "sonar.userHome"
 
 export SONAR_USER_HOME="$PWD/.sonar"
 

--- a/4/bin/entrypoint.sh
+++ b/4/bin/entrypoint.sh
@@ -1,7 +1,6 @@
 #!/bin/bash
 
-set -e
-set -o pipefail
+set -euo pipefail
 
 export SONAR_USER_HOME="$PWD/.sonar"
 sonar-scanner

--- a/DEVELOPER.md
+++ b/DEVELOPER.md
@@ -26,60 +26,60 @@ To analysis the project in the current directory:
 docker run --user="$(id -u):$(id -g)" -it -v "$PWD:/usr/src" sonarsource/sonar-scanner-cli
 ```
 
-If SQ is running on another port, you must specify it in your project's `sonar-project.properties` with `sonar.host.url=http://localhost:9010` and execute the same `docker run` command.
+If SQ is running on another port, you can specify it by adding the following to the `docker run` command:
+
+```
+-e SONAR_HOST_URL=http://localhost:9010
+```
 
 ### With SonarQube running in Docker
 
-First create a network and boot SonarQube:
+Create a network and boot SonarQube:
 
 ```
 docker network create "scanner-sq-network"
 docker run --network="scanner-sq-network" --name="sq" -d sonarqube
 ```
 
-Update the `sonar-project.properties` file in the project to analyse to specify the URL of SonarQube with `sonar.host.url=http://sq:9000`.
-
-Finally run the scanner:
+And run the scanner:
 
 ```
 # make sure SQ is up and running
-docker run --network="scanner-sq-network" --user="$(id -u):$(id -g)" -it -v "/path/to/project:/usr/src" sonarsource/sonar-scanner-cli
+docker run -e SONAR_HOST_URL=http://sq:9000 --network="scanner-sq-network" --user="$(id -u):$(id -g)" -it -v "/path/to/project:/usr/src" sonarsource/sonar-scanner-cli
 ```
 
 ## On Mac
 
 ### With local SonarQube
 
-Specify the SQ URL in the `sonar-project.properties` of the project to be analyzed with as `sonar.host.url=http://host.docker.internal:9000` (`host.docker.internal` should be used instead of `localhost`).
+On Mac, `host.docker.internal` should be used instead of `localhost`.
 
 To analyse the project located in `/path/to/project`, execute:
 
 ```
-docker run -it -v "/path/to/project:/usr/src" sonarsource/sonar-scanner-cli
+docker run -e SONAR_HOST_URL==http://host.docker.internal:9000 -it -v "/path/to/project:/usr/src" sonarsource/sonar-scanner-cli
 ```
 
 To analyse the project in the current directory, execute:
 
 ```
-docker run -it -v "$(pwd):/usr/src" sonarsource/sonar-scanner-cli
+docker run -e SONAR_HOST_URL==http://host.docker.internal:9000 -it -v "$(pwd):/usr/src" sonarsource/sonar-scanner-cli
 ```
 
 ### With SonarQube running in Docker
 
-First create a network and boot SonarQube:
+Create a network and boot SonarQube:
 
 ```
 docker network create "scanner-sq-network"
 docker run --network="scanner-sq-network" --name="sq" -d sonarqube
 ```
 
-Update the `sonar-project.properties` file in the project to analyse to specify the URL of SonarQube with `sonar.host.url=http://sq:9000`.
-
-Finally run the scanner:
+And run the scanner:
 
 ```
 # make sure SQ is up and running
-docker run --network="scanner-sq-network" -it -v "/path/to/project:/usr/src" sonarsource/sonar-scanner-cli
+docker run -e SONAR_HOST_URL==http://sq:9000 --network="scanner-sq-network" -it -v "/path/to/project:/usr/src" sonarsource/sonar-scanner-cli
 ```
 
 # How to publish the Docker image

--- a/DEVELOPER.md
+++ b/DEVELOPER.md
@@ -17,13 +17,13 @@ docker build --tag scanner-cli 4
 With a SonarQube (SQ) running on default configuration (`http://localhost:9000`), the following will analyse the project in directory `/path/to/project`:
 
 ```
-docker run -network=host --user="$(id -u):$(id -g)" -it -v "/path/to/project:/usr/src" sonarsource/sonar-scanner-cli
+docker run --user="$(id -u):$(id -g)" -it -v "/path/to/project:/usr/src" sonarsource/sonar-scanner-cli
 ```
 
 To analysis the project in the current directory:
 
 ```
-docker run -network=host --user="$(id -u):$(id -g)" -it -v "$PWD:/usr/src" sonarsource/sonar-scanner-cli
+docker run --user="$(id -u):$(id -g)" -it -v "$PWD:/usr/src" sonarsource/sonar-scanner-cli
 ```
 
 If SQ is running on another port, you must specify it in your project's `sonar-project.properties` with `sonar.host.url=http://localhost:9010` and execute the same `docker run` command.

--- a/README.md
+++ b/README.md
@@ -24,13 +24,13 @@ To analyse the project in directory `/path/to/project`, you must first provide t
 You can then run the following command:
 
 ```
-docker run --network=host --user="$(id -u):$(id -g)" -it -v "/path/to/project:/usr/src" sonarsource/sonar-scanner-cli
+docker run --user="$(id -u):$(id -g)" -it -v "/path/to/project:/usr/src" sonarsource/sonar-scanner-cli
 ```
 
 To analysis the project in the current directory:
 
 ```
-docker run --network=host --user="$(id -u):$(id -g)" -it -v "$PWD:/usr/src" sonarsource/sonar-scanner-cli
+docker run --user="$(id -u):$(id -g)" -it -v "$PWD:/usr/src" sonarsource/sonar-scanner-cli
 ```
 
 ### Write permissions

--- a/run-tests.sh
+++ b/run-tests.sh
@@ -90,6 +90,7 @@ create_scanner_cache() {
 test_scanner() {
   local scanner_finished_successfuly=no container_name
   local image="$1"
+  local args=""
   container_name=$(generate_id)
   info "testing image $1 in container $container_name"
 
@@ -97,10 +98,14 @@ test_scanner() {
 
   scanner_props_location="$PWD/$container_name/sonarqube-scanner/sonar-project.properties"
   echo "sonar.projectKey=$container_name-test" >> "$scanner_props_location"
-  echo "sonar.host.url=http://${sonarqube_container_name}:9000" >> "$scanner_props_location"
-  echo "sonar.userHome=/usr/.sonar" >> "$scanner_props_location"
-
-  docker run --network="$network" --name="$container_name" --user="$(id -u):$(id -g)" -it -v "$PWD/$container_name/sonarqube-scanner:/usr/src" -v "${scanner_cache}:/usr/.sonar" "$image"
+  
+  docker run --network="$network" \
+     --name="$container_name" \
+     --user="$(id -u):$(id -g)" \
+     -it \
+     -v "$PWD/$container_name/sonarqube-scanner:/usr/src" -v "${scanner_cache}:/usr/.sonar" \
+     --env SONAR_HOST_URL="http://${sonarqube_container_name}:9000" --env SONAR_USER_HOME="/usr/.sonar" \
+      "$image"
   containers+=("$container_name")
   docker wait "$container_name"
   info "Container $container_name stopped."


### PR DESCRIPTION
this should resolves #8 by adding support for the following environment variables:

1. ~~`SONAR_HOST_URL`: URL to the SonarQube server, maps to property `sonar.host.url`~~ natively support by sonar-scanner-cli 4.2+
2. `SONAR_LOGIN`: login to the SonarQube server, could be a token instead of a login, maps to property `sonar.login`
3. `SONAR_PASSWORD`: password to the SonarQube server, maps to property `sonar.password`
4. `SONAR_USER_HOME`: location of the `.sonar` directory, maps to property `sonar.userHome`
4. `SONAR_PROJECT_DIR`: location of the directory inside the container where the project to analyse is located (`/usr/src` by default)

#17 has been merged, the documentation is also updated by this PR: usage of env variables should be documented as the are less intrusive (no need to modify the project's `sonar-project.properties` file) and support Docker Secret