### PR TITLE
simplify container usage

### DIFF
--- a/4/Dockerfile
+++ b/4/Dockerfile
@@ -36,3 +36,5 @@ WORKDIR /usr/src
 USER scanner-cli
 
 ENTRYPOINT ["/usr/bin/entrypoint.sh"]
+
+CMD ["sonar-scanner"]

--- a/4/bin/entrypoint.sh
+++ b/4/bin/entrypoint.sh
@@ -21,5 +21,9 @@ if [ "${SONAR_PROJECT_BASE_DIR:-}" ]; then
 fi
 
 export SONAR_USER_HOME="$PROJECT_BASE_DIR/.sonar"
-sonar-scanner "${args[@]}"
 
+if [ "${1#-}" != "${1}" ] || [ -z "$(command -v "${1}")" ]; then
+  set -- sonar-scanner "${args[@]}"
+fi
+
+exec "$@"


### PR DESCRIPTION
- modifies `entrypoint` to allow calls like `docker run sonarsource/sonar-scanner-cli bash` and `docker run sonarsource/sonar-scanner-cli --version` or usage in Jenkins as described in #30  

copied from [nodejs/docker-node](https://github.com/nodejs/docker-node/blob/master/12/stretch/docker-entrypoint.sh)

fixes #30 