### PR TITLE
allow adding of custom certificates to trust store

### DIFF
--- a/4/Dockerfile
+++ b/4/Dockerfile
@@ -23,6 +23,7 @@ RUN wget -U "scannercli" -q -O /opt/sonar-scanner-cli.zip https://binaries.sonar
     && unzip sonar-scanner-cli.zip \
     && rm sonar-scanner-cli.zip \
     && mv sonar-scanner-${SONAR_SCANNER_VERSION}-linux ${SONAR_SCANNER_HOME} \
+    && chown --recursive scanner-cli:scanner-cli ${SONAR_SCANNER_HOME} \
     && wget -U "nodejs" -q -O nodejs.tar.xz https://nodejs.org/dist/${NODEJS_VERSION}/node-${NODEJS_VERSION}-linux-x64.tar.xz \
     && tar Jxf nodejs.tar.xz \
     && rm nodejs.tar.xz \


### PR DESCRIPTION
We have the requirement that we need to add certificates to the JAVA  truststore (`/opt/sonar-scanner/jre/conf/security/cacerts`) using the JAVA `keytool`.

While https://github.com/SonarSource/sonar-scanner-cli/pull/79 adds the `keytool` to the bundled JRE, this PR targets to make the `/ops/sonar-scanner/` directory writable for the `keytool`.