### PR TITLE
Add support for projectKey and projectName

### DIFF
--- a/4/bin/entrypoint.sh
+++ b/4/bin/entrypoint.sh
@@ -12,6 +12,8 @@ add_env_var_as_env_prop() {
 
 add_env_var_as_env_prop "${SONAR_LOGIN:-}" "sonar.login"
 add_env_var_as_env_prop "${SONAR_PASSWORD:-}" "sonar.password"
+add_env_var_as_env_prop "${SONAR_PROJECT_KEY:-}" "sonar.projectKey"
+add_env_var_as_env_prop "${SONAR_PROJECT_NAME:-}" "sonar.projectName"
 add_env_var_as_env_prop "${SONAR_USER_HOME:-}" "sonar.userHome"
 add_env_var_as_env_prop "${SONAR_PROJECT_BASE_DIR:-}" "sonar.projectBaseDir"
 
@@ -22,4 +24,3 @@ fi
 
 export SONAR_USER_HOME="$PROJECT_BASE_DIR/.sonar"
 sonar-scanner "${args[@]}"
-

--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ This image is currently in Beta testing and is made available to gather feedback
 Have Question or Feedback?
 --------------------------
 
-For support questions ("How do I?", "I got this error, why?", ...), please first read the [documentation](https://docs.sonarqube.org) and then head to the [SonarSource forum](https://community.sonarsource.com/). There are chances that a question similar to yours has already been answered. 
+For support questions ("How do I?", "I got this error, why?", ...), please first read the [documentation](https://docs.sonarqube.org) and then head to the [SonarSource forum](https://community.sonarsource.com/). There are chances that a question similar to yours has already been answered.
 
 Be aware that this forum is a community, so the standard pleasantries ("Hi", "Thanks", ...) are expected. And if you don't get an answer to your thread, you should sit on your hands for at least three days before bumping it. Operators are not standing by. :-)
 
@@ -79,6 +79,11 @@ docker run -e SONAR_HOST_URL=http://foo.acme:9000 -it -v "$(pwd):/usr/src" sonar
 * `SONAR_HOST_URL`: URL to the SonarQube instance the scanner should connect to (default=`http://localhost:9000`)
 * `SONAR_TOKEN`: the prefered way to authenticate to SonarQube is to use a token. Use this environment variable to pass it to the scanner
 * `SONAR_LOGIN` and `SONAR_PASSWORD`: alternatively, you can provide the SonarQube username and password for the scanner to use using these two variables
+
+### Project configuration
+
+* `SONAR_PROJECT_KEY`: The project's unique key
+* `SONAR_PROJECT_NAME`: Name of the project that will be displayed on the web interface
 
 ### Project mounting point
 


### PR DESCRIPTION
Currently we're not able to define `sonar.projectKey` and `sonar.projectName` on the fly as environment variables. This PR fixes that:

```
docker run -e SONAR_HOST_URL -e SONAR_LOGIN -e SONAR_PROJECT_KEY -e SONAR_PROJECT_NAME --user="$(id -u):$(id -g)" -it -v "$PWD:/usr/src" sonarsource/sonar-scanner-cli
```