### PR TITLE
fix: Allow to pass extra parameters to command

### DIFF
--- a/4/bin/entrypoint.sh
+++ b/4/bin/entrypoint.sh
@@ -23,7 +23,7 @@ fi
 export SONAR_USER_HOME="$PROJECT_BASE_DIR/.sonar"
 
 if [ "${1#-}" != "${1}" ] || [ -z "$(command -v "${1}")" ]; then
-  set -- sonar-scanner "${args[@]}"
+  set -- sonar-scanner "${args[@]}" $*
 fi
 
 exec "$@"


### PR DESCRIPTION
As explained in comment https://github.com/SonarSource/sonar-scanner-cli-docker/pull/31#discussion_r422533559 currently is not possible to run the entrypoint with extra parameters by default. This PR fixes that, allowing to run it like that:
`docker run -e SONAR_HOST_URL=http://foo.acme:9000 --user="$(id -u):$(id -g)" -it -v "/path/to/project:/usr/src" sonarsource/sonar-scanner-cli -Dsonar.projectVersion=foo -Dsonar.projectKey=bar
`