### PR TITLE
add workflow for Dockerfile linting

### DIFF
--- a/.github/workflows/hadolint-analysis.yml
+++ b/.github/workflows/hadolint-analysis.yml
@@ -8,7 +8,7 @@ on:
     - '**/Dockerfile'
 
 jobs:
-  4:
+  v4:
     name: Dockerfile-Linting
     runs-on: ubuntu-latest
     steps:

--- a/.github/workflows/hadolint-analysis.yml
+++ b/.github/workflows/hadolint-analysis.yml
@@ -1,0 +1,19 @@
+name: "QA"
+
+on:
+  pull_request:
+    branches: 
+    - master
+    paths:
+    - '**/Dockerfile'
+
+jobs:
+  4:
+    name: Dockerfile-Linting
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v2
+    - name: Pull HaDoLint image
+      run: docker pull hadolint/hadolint
+    - name: Lint Dockerfile
+      run: docker run --rm --interactive hadolint/hadolint < ./4/Dockerfile

--- a/.github/workflows/hadolint-analysis.yml
+++ b/.github/workflows/hadolint-analysis.yml
@@ -16,4 +16,4 @@ jobs:
     - name: Pull HaDoLint image
       run: docker pull hadolint/hadolint
     - name: Lint Dockerfile
-      run: docker run --rm --interactive hadolint/hadolint < ./4/Dockerfile
+      run: docker run --rm --interactive hadolint/hadolint hadolint --ignore DL3008 - < ./4/Dockerfile


### PR DESCRIPTION
With the upcoming major Dockerfiles changes in mind, it might be good to stick to and assure some best practices. 
[HaDoLint](https://github.com/hadolint/hadolint) has a good [set of rules](https://github.com/hadolint/hadolint#rules) to verify Dockerfiles.

[Here](https://github.com/CCFenner/sonar-scanner-cli-docker/pull/1/checks?check_run_id=729895633) a sample run how it looks like.