### PR TITLE
SQSCANNER-68 - Automatically trigger docker release on new CLI release

### DIFF
--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -1,24 +1,22 @@
-name: Update image dependencies
+name: Nightly
 
 on:
   schedule:
     - cron: '30 12 * * *'
 
 jobs:
-  update-image-dependencies:
+  nightly:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
-        with:
-          ref: 4.4
       - uses: actions/checkout@v2
         with:
           repository: SonarSource/sonar-scanning-examples
           path: target_repository
       - name: Build image
-        run: docker build "4" --tag "sonarsource/sonar-scanner-cli:4.4" --tag "sonarsource/sonar-scanner-cli:4" --tag "sonarsource/sonar-scanner-cli:latest"
+        run: docker build "4" --tag "sonarsource/sonar-scanner-cli:latest"
       - name: Test image
-        run: ./run-tests.sh "sonarsource/sonar-scanner-cli:4.4"
+        run: ./run-tests.sh "sonarsource/sonar-scanner-cli:latest"
       - name: Push image
         run: docker login -u ${{ secrets.DOCKER_USERNAME }} -p ${{ secrets.DOCKER_PASSWORD }} && docker push sonarsource/sonar-scanner-cli
 

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -2,7 +2,7 @@ name: Nightly
 
 on:
   schedule:
-    - cron: '30 12 * * *'
+    - cron: '0 1 * * *'
 
 jobs:
   nightly:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,50 @@
+name: Release
+
+on:
+  release:
+    types:
+    - published
+
+jobs:
+  release:
+    runs-on: ubuntu-latest
+    name: Start release process
+    steps:
+    - name: Get the version
+      id: get_version
+      run: |
+        IFS=. read major minor micro build <<<"${{ github.event.release.tag_name }}"
+        echo ::set-output name=cli_version::${{ github.event.release.tag_name }}
+        echo ::set-output name=major_version::"${major}"
+        echo ::set-output name=version::"${major}.${minor}"
+      shell: bash
+    - uses: actions/checkout@v2
+      with:
+        ref: ${{ GITHUB_REF }}
+    - uses: actions/checkout@v2
+      with:
+        repository: SonarSource/sonar-scanning-examples
+        path: target_repository
+    - name: Build image
+      run: |
+        docker build "${{ steps.get_version.outputs.major_version }}" \
+          --tag "sonarsource/sonar-scanner-cli:${{ steps.get_version.outputs.major_version }}" \
+          --tag "sonarsource/sonar-scanner-cli:${{ steps.get_version.outputs.version }}" \
+          --build-arg SONAR_SCANNER_VERSION=${{ steps.get_version.outputs.cli_version }}
+    - name: Test image
+      run: ./run-tests.sh "sonarsource/sonar-scanner-cli:${{ steps.get_version.outputs.version }}"
+    - name: Push image
+      run: docker login -u ${{ secrets.DOCKER_USERNAME }} -p ${{ secrets.DOCKER_PASSWORD }} && docker push sonarsource/sonar-scanner-cli
+    - name: Notify success on Slack
+      uses: Ilshidur/action-slack@2.0.0
+      env:
+        SLACK_WEBHOOK: ${{ secrets.SLACK_WEBHOOK }}
+      with:
+        args: "Release successful for {{ GITHUB_REPOSITORY }} by {{ GITHUB_ACTOR }}"
+    - name: Notify failures on Slack
+      uses: Ilshidur/action-slack@2.0.0
+      if: failure()
+      env:
+        SLACK_WEBHOOK: ${{ secrets.SLACK_WEBHOOK }}
+      with:
+        args: "Release failed, see the logs at https://github.com/{{ GITHUB_REPOSITORY }}/actions by {{ GITHUB_ACTOR }}"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -30,11 +30,16 @@ jobs:
         docker build "${{ steps.get_version.outputs.major_version }}" \
           --tag "sonarsource/sonar-scanner-cli:${{ steps.get_version.outputs.major_version }}" \
           --tag "sonarsource/sonar-scanner-cli:${{ steps.get_version.outputs.version }}" \
+          --tag "sonarsource/sonar-scanner-cli:latest" \
           --build-arg SONAR_SCANNER_VERSION=${{ steps.get_version.outputs.cli_version }}
     - name: Test image
       run: ./run-tests.sh "sonarsource/sonar-scanner-cli:${{ steps.get_version.outputs.version }}"
     - name: Push image
-      run: docker login -u ${{ secrets.DOCKER_USERNAME }} -p ${{ secrets.DOCKER_PASSWORD }} && docker push sonarsource/sonar-scanner-cli
+      run: |
+        docker login -u ${{ secrets.DOCKER_USERNAME }} -p ${{ secrets.DOCKER_PASSWORD }} && \
+        docker push sonarsource/sonar-scanner-cli:${{ steps.get_version.outputs.major_version }} && \
+        docker psuh sonarsource/sonar-scanner-cli:${{ steps.get_version.outputs.version }} && \
+        docker push sonarsource/sonar-scanner-cli:latest
     - name: Notify success on Slack
       uses: Ilshidur/action-slack@2.0.0
       env:


### PR DESCRIPTION
New actions separating the release of a new version and the nightly builds.

Not in scope of this PR is the updating of the lagged docker images on vuln updates.

- nightly action will run using the existing cron to only update the "latest" tag of the docker image
- release action will run when a new release is published using the SonarSource version format. It will checkout this tag and release the two associated container image tags, namely "major" and "major.minor" The tag version is also used to determine the CLI version to download and install.