### PR TITLE
SQSCANNER-90 Fix NODE_PATH env variable

### DIFF
--- a/4/Dockerfile
+++ b/4/Dockerfile
@@ -10,6 +10,7 @@ ENV JAVA_HOME=/opt/java/openjdk \
     SONAR_SCANNER_HOME=${SONAR_SCANNER_HOME} \
     SONAR_USER_HOME=${SONAR_SCANNER_HOME}/.sonar \
     PATH=/opt/java/openjdk/bin:${SONAR_SCANNER_HOME}/bin:${PATH} \
+    NODE_PATH=/usr/lib/node_modules \
     SRC_PATH=/usr/src
 
 WORKDIR /opt


### PR DESCRIPTION
This started failing after https://github.com/SonarSource/sonar-scanner-cli-docker/commit/0ccb3d036248d1bd8bd07624468e296e037917a0.

First, `NODEJS_HOME` was removed (https://github.com/SonarSource/sonar-scanner-cli-docker/commit/0ccb3d036248d1bd8bd07624468e296e037917a0), which made `NODE_PATH` point to `/lib/node_modules` (which doesn't exist). Later, setting `NODE_PATH` was removed as well (https://github.com/SonarSource/sonar-scanner-cli-docker/commit/948d0d9bafc715f8fb1cf4fc4f7c91e8d2edaa2a), but this variable is relied upon by SonarJS.

This re-instates the `NODE_PATH` variable, and points it to the correct location (for Alpine). Side note: apparently, NodeJS on Alpine doesn't set `NODE_PATH` nor `NODEJS_HOME` by default. So we cannot rely on them to construct this path. Hardcoding seems the best option.