### PR TITLE
SQSCANNER-93 fixed wrong npm version

### DIFF
--- a/4/Dockerfile
+++ b/4/Dockerfile
@@ -19,7 +19,7 @@ RUN set -ex \
     && addgroup -S -g ${GID} scanner-cli \
     && adduser -S -D -u ${UID} -G scanner-cli scanner-cli \
     && apk add --no-cache --virtual build-dependencies wget unzip gnupg \
-    && apk add --no-cache git python3 py-pip bash shellcheck 'nodejs>10' 'npm>10' \
+    && apk add --no-cache git python3 py-pip bash shellcheck 'nodejs>10' 'npm>7' \
     && wget -U "scannercli" -q -O /opt/sonar-scanner-cli.zip https://binaries.sonarsource.com/Distribution/sonar-scanner-cli/sonar-scanner-cli-${SONAR_SCANNER_VERSION}.zip \
     && wget -U "scannercli" -q -O /opt/sonar-scanner-cli.zip.asc https://binaries.sonarsource.com/Distribution/sonar-scanner-cli/sonar-scanner-cli-${SONAR_SCANNER_VERSION}.zip.asc \
     && wget -U "scannercli" -q -O /opt/sonarsource-public.key https://binaries.sonarsource.com/sonarsource-public.key \


### PR DESCRIPTION
The Base image has updated to alpine 1.14 and with that the node.js and the npm package got split in two separate packages as npm is following a different release cycle (see [upstream commit here](https://gitlab.alpinelinux.org/alpine/aports/-/commit/25b10bd1a93e12a7e49fee38b0a229281ae49fb7)). 
This commit will fix the npm version to the correct one that is independent from the nodejs package.