### PR TITLE
[NO-JIRA] Alert GH Action Failures on Slack

### DIFF
--- a/.github/workflows/hadolint-analysis.yml
+++ b/.github/workflows/hadolint-analysis.yml
@@ -17,3 +17,4 @@ jobs:
       run: docker pull hadolint/hadolint
     - name: Lint Dockerfile
       run: docker run --rm --interactive hadolint/hadolint hadolint --ignore DL3018 --ignore DL4001 --ignore DL3013 --ignore SC2015 - < ./4/Dockerfile
+    

--- a/.github/workflows/qa.yml
+++ b/.github/workflows/qa.yml
@@ -27,6 +27,7 @@ jobs:
       - name: Build image
         run: |
           docker build "${{ matrix.version }}" \
+            --pull \
             --tag "sonar-scanner-cli:${{ matrix.tag }}" \
             --build-arg SONAR_SCANNER_VERSION=${{ steps.latest_release.outputs.tag_name }}
       - name: Test image

--- a/.github/workflows/qa.yml
+++ b/.github/workflows/qa.yml
@@ -38,3 +38,4 @@ jobs:
           image-ref: sonar-scanner-cli:${{ matrix.tag }}
           exit-code: 1
           ignore-unfixed: true
+

--- a/.github/workflows/rebuild.yml
+++ b/.github/workflows/rebuild.yml
@@ -21,6 +21,7 @@ jobs:
           image-ref: 'docker.io/sonarsource/sonar-scanner-cli'
           exit-code: 1
           ignore-unfixed: true
+
   base-image:
     name: Check for newer base image
     runs-on: ubuntu-latest
@@ -45,6 +46,7 @@ jobs:
         else
           echo "::set-output name=changed::false"
         fi
+
   build:
     name: Build & Push
     needs:
@@ -99,3 +101,10 @@ jobs:
           docker push repox-sonarsource-docker-releases.jfrog.io/sonarsource/sonar-scanner-cli:${{ steps.get_version.outputs.major_minor_patch }}
           docker push repox-sonarsource-docker-releases.jfrog.io/sonarsource/sonar-scanner-cli:${{ steps.get_version.outputs.major_minor }}
           docker push repox-sonarsource-docker-releases.jfrog.io/sonarsource/sonar-scanner-cli:${{ steps.get_version.outputs.major }}
+      - name: Notify failures on Slack
+        if: failure()
+        uses: Ilshidur/action-slack@2.0.0
+        env:
+          SLACK_WEBHOOK: ${{ secrets.SLACK_SQ_DEVOPS_WEBHOOK }}
+        with:
+          args: "Build and Push for sonar-scanner-cli-docker failed, see the logs at https://github.com/SonarSource/sonar-scanner-cli-docker/actions"

--- a/.github/workflows/rebuild.yml
+++ b/.github/workflows/rebuild.yml
@@ -71,8 +71,6 @@ jobs:
           echo ::set-output name=major::"${major}"
           echo ::set-output name=major_minor::"${major}.${minor}"
           echo ::set-output name=major_minor_patch::"${major}.${minor}.${patch}"
-      - name: Pull docker image
-        run: docker pull docker.io/sonarsource/sonar-scanner-cli:latest
       - name: Build an image from Dockerfile
         run: |
           docker build "4" \


### PR DESCRIPTION
Similar to https://github.com/SonarSource/docker-sonarqube/pull/543

I'd like to make sure that we are notified on [#team-sq-devops](https://sonarsource.slack.com/archives/C0372LQ1N06) for whenever a GH action of this repo fails.

I don't have access to set up secrets on this repo. @tobias-trabelsi-sonarsource could you set that? The webhook url could be that of the [App](https://api.slack.com/apps/A0376E7S685/incoming-webhooks?) we created for this.

Side note: does anyone besides you @tobias-trabelsi-sonarsource have access to set up secrets for this repo?