### PR TITLE
SQSCANNER-103 DOCKER-52 Updating Alpine to 3.15. Fixes zlib bug.

### DIFF
--- a/.github/workflows/rebuild.yml
+++ b/.github/workflows/rebuild.yml
@@ -34,14 +34,14 @@ jobs:
         service_account_key: ${{ secrets.GCP_SA_KEY }}
         export_default_credentials: true
     - name: Pull base image
-      run: docker pull alpine:3.14
+      run: docker pull alpine:3.15
     - name: Check base image hash
       id: hash
       run: |
-        NEW_IMAGE_ID=$(docker image inspect --format='{{.ID}}' alpine:3.14)
-        OLD_IMAGE_ID=$(gsutil cat gs://github_action-sonar_scanner_cli_docker/alpine:3.14.hash || echo "Hash not found")
+        NEW_IMAGE_ID=$(docker image inspect --format='{{.ID}}' alpine:3.15)
+        OLD_IMAGE_ID=$(gsutil cat gs://github_action-sonar_scanner_cli_docker/alpine:3.15.hash || echo "Hash not found")
         if [[ "$NEW_IMAGE_ID" != "$OLD_IMAGE_ID" ]]; then
-          echo $NEW_IMAGE_ID | gsutil cp - gs://github_action-sonar_scanner_cli_docker/alpine:3.14.hash
+          echo $NEW_IMAGE_ID | gsutil cp - gs://github_action-sonar_scanner_cli_docker/alpine:3.15.hash
           echo "::set-output name=changed::true"
         else
           echo "::set-output name=changed::false"

--- a/4/Dockerfile
+++ b/4/Dockerfile
@@ -1,4 +1,4 @@
-FROM alpine:3.14
+FROM alpine:3.15
 
 ARG SONAR_SCANNER_HOME=/opt/sonar-scanner
 ARG SONAR_SCANNER_VERSION


### PR DESCRIPTION
SQSCANNER-103
DOCKER-52

This PR bumps version of Alpine to 3.15.

This will kill the noise about zlib bug present in older Alpine versions. More information here https://discuss.sonarsource.com/t/4-7-scanner-docker-image-causing-errors-compared-to-4-6/10344 

Also 3.15 is the current version of Docker SonarQube introduced [here](https://github.com/SonarSource/docker-sonarqube/commit/1f65e4d4f3811c49373974d78ea532415833aa46) and Tobias suggested to keep both the same [here](https://github.com/SonarSource/sonar-scanner-cli-docker/pull/126)

I will suggest to the scanner-guild releasing 4.7.1 or 4.8 version of this project after this PR is merged.