### PR TITLE
chore(ci): add labels to docker images

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -42,6 +42,9 @@ jobs:
       - name: Build image
         run: |
           docker build "${{ steps.get_version.outputs.major_version }}" \
+            --label "org.opencontainers.image.url=${{ github.server_url }}/${{ github.repository }}" \
+            --label "org.opencontainers.image.revision=${ {github.sha }}" \
+            --label "org.opencontainers.image.version=${{ steps.get_version.outputs.major_minor_patch }}" \
             --tag "sonarsource/sonar-scanner-cli:${{ steps.get_version.outputs.major_version }}" \
             --tag "repox-sonarsource-docker-releases.jfrog.io/sonarsource/sonar-scanner-cli:${{ steps.get_version.outputs.major_version }}" \
             --tag "sonarsource/sonar-scanner-cli:${{ steps.get_version.outputs.major_minor }}" \


### PR DESCRIPTION
The images published to https://hub.docker.com/r/sonarsource/sonar-scanner-cli do not have [OCI image annotations](
https://github.com/opencontainers/image-spec/blob/main/annotations.md#pre-defined-annotation-keys), such as `org.opencontainers.image.source`

These annotations are useful for people to manual use as well as for use by tools. For example, [Snyk uses them in its UI](https://snyk.io/blog/how-and-when-to-use-docker-labels-oci-container-annotations/) and [Renovate uses them to find release notes](https://github.com/renovatebot/renovate/blob/34.115.1/lib/modules/datasource/docker/readme.md).

Fixes: https://github.com/SonarSource/sonar-scanner-cli-docker/issues/159

---

Please be aware that we are not actively looking for feature contributions. The truth is that it's extremely difficult for someone outside SonarSource to comply with our roadmap and expectations. Therefore, we typically only accept minor cosmetic changes and typo fixes. If you would like to see a new feature, please create a new thread in the forum ["Suggest new features"](https://community.sonarsource.com/c/suggestions/features).

With that in mind, if you would like to submit a code contribution, make sure that you adhere to the following guidelines and all tests are passing:

- [X] Please explain your motives to contribute this change: what problem you are trying to fix, what improvement you are trying to make
- [X] Use the following formatting style: [SonarSource/sonar-developer-toolset](https://github.com/SonarSource/sonar-developer-toolset#code-style)
- [X] If there is a [JIRA](http://jira.sonarsource.com/browse/SQSCANNER) ticket available, please make your commits and pull request start with the ticket ID (SQSCANNER-XXXX)

We will try to give you feedback on your contribution as quickly as possible.

Thank You!
The SonarSource Team
