### PR TITLE
Update Java version to openjdk17

### DIFF
--- a/4/Dockerfile
+++ b/4/Dockerfile
@@ -4,7 +4,7 @@ ARG SONAR_SCANNER_HOME=/opt/sonar-scanner
 ARG SONAR_SCANNER_VERSION
 ARG UID=1000
 ARG GID=1000
-ENV JAVA_HOME=/usr/lib/jvm/java-11-openjdk \
+ENV JAVA_HOME=/usr/lib/jvm/java-17-openjdk \
     HOME=/tmp \
     XDG_CONFIG_HOME=/tmp \
     SONAR_SCANNER_HOME=${SONAR_SCANNER_HOME} \
@@ -21,7 +21,7 @@ RUN set -eux; \
     addgroup -S -g ${GID} scanner-cli; \
     adduser -S -D -u ${UID} -G scanner-cli scanner-cli; \
     apk add --no-cache --virtual build-dependencies wget unzip gnupg; \
-    apk add --no-cache git python3 py-pip bash shellcheck 'nodejs>12' openjdk11-jre curl musl-locales musl-locales-lang; \
+    apk add --no-cache git python3 py-pip bash shellcheck 'nodejs>12' openjdk17-jre curl musl-locales musl-locales-lang; \
     wget -U "scannercli" -q -O /opt/sonar-scanner-cli.zip https://binaries.sonarsource.com/Distribution/sonar-scanner-cli/sonar-scanner-cli-${SONAR_SCANNER_VERSION}.zip; \
     wget -U "scannercli" -q -O /opt/sonar-scanner-cli.zip.asc https://binaries.sonarsource.com/Distribution/sonar-scanner-cli/sonar-scanner-cli-${SONAR_SCANNER_VERSION}.zip.asc; \
     for server in $(shuf -e hkps://keys.openpgp.org \


### PR DESCRIPTION
Hello,

I updated the Java version of my SonarQube server to Java 17 (which is also the minimum version for the version 9.9 LTS).
From there, I could not run sonar-scanner from the Docker image as it still uses Java 11.
The Java version of sonar-scanner-cli-docker must be updated to Java 17, which is what this pull request does.

Best regards,
Yorick