### PR TITLE
DOCKER-164: Add org.opencontainers.image.url label

### DIFF
--- a/4/Dockerfile
+++ b/4/Dockerfile
@@ -1,5 +1,7 @@
 FROM alpine:3.17
 
+LABEL org.opencontainers.image.url=https://github.com/SonarSource/sonar-scanner-cli-docker
+
 ARG SONAR_SCANNER_HOME=/opt/sonar-scanner
 ARG SONAR_SCANNER_VERSION
 ARG UID=1000


### PR DESCRIPTION
Add the org.opencontainers.image.url label to the docker image.

These annotations are useful for people to manual use as well as for use by tools. For example, Snyk uses them in its UI and Renovate uses them to find release notes.

See: https://github.com/opencontainers/image-spec/blob/main/annotations.md#pre-defined-annotation-keys

Please be aware that we are not actively looking for feature contributions. The truth is that it's extremely difficult for someone outside SonarSource to comply with our roadmap and expectations. Therefore, we typically only accept minor cosmetic changes and typo fixes. If you would like to see a new feature, please create a new thread in the forum ["Suggest new features"](https://community.sonarsource.com/c/suggestions/features).

With that in mind, if you would like to submit a code contribution, make sure that you adhere to the following guidelines and all tests are passing:

- [ ] Please explain your motives to contribute this change: what problem you are trying to fix, what improvement you are trying to make
- [ ] Use the following formatting style: [SonarSource/sonar-developer-toolset](https://github.com/SonarSource/sonar-developer-toolset#code-style)
- [ ] If there is a [JIRA](http://jira.sonarsource.com/browse/SQSCANNER) ticket available, please make your commits and pull request start with the ticket ID (SQSCANNER-XXXX)

We will try to give you feedback on your contribution as quickly as possible.

Thank You!
The SonarSource Team
