### PR TITLE
Update used node version to LTS

### DIFF
--- a/4/Dockerfile
+++ b/4/Dockerfile
@@ -20,6 +20,7 @@ WORKDIR /opt
 RUN set -eux; \
     groupadd --system --gid 1000 scanner-cli; \
     useradd --system --uid 1000 --gid scanner-cli scanner-cli; \
+    curl -fsSL https://deb.nodesource.com/setup_lts.x | bash -; \
     apt-get update; \
     apt-get install -y --no-install-recommends gnupg unzip wget bash fonts-dejavu python3 python3-pip shellcheck nodejs>14 build-essential; \
     wget -U "scannercli" -q -O /opt/sonar-scanner-cli.zip https://binaries.sonarsource.com/Distribution/sonar-scanner-cli/sonar-scanner-cli-${SONAR_SCANNER_VERSION}.zip; \

--- a/4/Dockerfile
+++ b/4/Dockerfile
@@ -21,7 +21,7 @@ RUN set -eux; \
     groupadd --system --gid 1000 scanner-cli; \
     useradd --system --uid 1000 --gid scanner-cli scanner-cli; \
     apt-get update; \
-    apt-get install -y --no-install-recommends gnupg unzip wget bash fonts-dejavu python3 python3-pip shellcheck nodejs>12 build-essential; \
+    apt-get install -y --no-install-recommends gnupg unzip wget bash fonts-dejavu python3 python3-pip shellcheck nodejs>14 build-essential; \
     wget -U "scannercli" -q -O /opt/sonar-scanner-cli.zip https://binaries.sonarsource.com/Distribution/sonar-scanner-cli/sonar-scanner-cli-${SONAR_SCANNER_VERSION}.zip; \
     wget -U "scannercli" -q -O /opt/sonar-scanner-cli.zip.asc https://binaries.sonarsource.com/Distribution/sonar-scanner-cli/sonar-scanner-cli-${SONAR_SCANNER_VERSION}.zip.asc; \
     for server in $(shuf -e hkps://keys.openpgp.org \

--- a/4/Dockerfile
+++ b/4/Dockerfile
@@ -22,7 +22,7 @@ RUN set -eux; \
     useradd --system --uid 1000 --gid scanner-cli scanner-cli; \
     curl -fsSL https://deb.nodesource.com/setup_lts.x | bash -; \
     apt-get update; \
-    apt-get install -y --no-install-recommends gnupg unzip wget bash fonts-dejavu python3 python3-pip shellcheck nodejs>14 build-essential; \
+    apt-get install -y --no-install-recommends gnupg unzip wget bash fonts-dejavu python3 python3-pip shellcheck nodejs build-essential; \
     wget -U "scannercli" -q -O /opt/sonar-scanner-cli.zip https://binaries.sonarsource.com/Distribution/sonar-scanner-cli/sonar-scanner-cli-${SONAR_SCANNER_VERSION}.zip; \
     wget -U "scannercli" -q -O /opt/sonar-scanner-cli.zip.asc https://binaries.sonarsource.com/Distribution/sonar-scanner-cli/sonar-scanner-cli-${SONAR_SCANNER_VERSION}.zip.asc; \
     for server in $(shuf -e hkps://keys.openpgp.org \


### PR DESCRIPTION
Github sonar action is failing due to node 12 no longer being accepted. Related issue https://community.sonarsource.com/t/sonarsource-sonarcloud-github-action-failing-with-node-js-12-error/89664

The Github action uses sonar-scanner-cli docker image as base image here https://github.com/SonarSource/sonarcloud-github-action/blob/master/Dockerfile so updating this is necessary.

----

- [x] Please explain your motives to contribute this change: what problem you are trying to fix, what improvement you are trying to make
- [x] Use the following formatting style: [SonarSource/sonar-developer-toolset](https://github.com/SonarSource/sonar-developer-toolset#code-style)
- [x] ~~If there is a [JIRA](http://jira.sonarsource.com/browse/SQSCANNER) ticket available, please make your commits and pull request start with the ticket ID (SQSCANNER-XXXX)~~ (No open ticket)
