### PR TITLE
Don't run tests during the release workflow

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -37,8 +37,8 @@ build_task:
     - docker build --tag "${STAGING_IMAGE_NAME}:scanner-${CI_BUILD_NUMBER}" --push .
 
 private_scan_task:
-  # run only on master and long-term branches
-  only_if: $CIRRUS_USER_COLLABORATOR == 'true' && ($CIRRUS_BRANCH == "master" || $CIRRUS_BRANCH =~ "branch-.*")
+  # run only on default and long-term branches
+  only_if: $CIRRUS_USER_COLLABORATOR == 'true' && ($CIRRUS_BRANCH == $CIRRUS_DEFAULT_BRANCH || $CIRRUS_BRANCH =~ "branch-.*")
   ec2_instance:
     <<: *VM_TEMPLATE
   login_script:
@@ -52,7 +52,7 @@ private_scan_task:
     - echo "Scan the ${STAGING_IMAGE_NAME}:scanner-${CI_BUILD_NUMBER} image"
     - docker pull "${STAGING_IMAGE_NAME}:scanner-${CI_BUILD_NUMBER}"
     - java -jar wss-unified-agent.jar -c .cirrus/wss-unified-agent.config -apiKey $MEND_API_KEY
-depends_on: build
+  depends_on: build
 
 public_scan_task: 
   only_if: $CIRRUS_CRON == 'nightly-mend-scan'
@@ -72,6 +72,7 @@ public_scan_task:
     - java -jar wss-unified-agent.jar -c .cirrus/wss-unified-agent.config -apiKey $MEND_API_KEY
 
 test_docker_builder:
+  <<: *ONLY_SONARSOURCE_QA
   login_script:
     - docker login --username $DOCKER_USERNAME --password $DOCKER_PASSWORD
   test_script:
@@ -83,6 +84,7 @@ test_docker_builder:
   depends_on: build
 
 sonar_scan_task:
+  <<: *ONLY_SONARSOURCE_QA
   eks_container:
     region: eu-central-1
     cluster_name: ${CIRRUS_CLUSTER_NAME}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -46,7 +46,7 @@ jobs:
         with:
           repository: SonarSource/sonar-scanning-examples
           path: target_repository
-      - name: Build image
+      - name: Pull staged image
         run: |
           docker login --username ${{ fromJSON(steps.secrets.outputs.vault).docker_username }} --password-stdin <<< "${{ fromJSON(steps.secrets.outputs.vault).docker_access_token }}"
           docker pull "sonarsource/sonarqube:scanner-${{ steps.get_version.outputs.buildnumber }}"
@@ -56,14 +56,6 @@ jobs:
           docker tag "sonarsource/sonarqube:scanner-${{ steps.get_version.outputs.buildnumber }}" "repox-sonarsource-docker-releases.jfrog.io/sonarsource/sonar-scanner-cli:${{ steps.get_version.outputs.major_minor }}"
           docker tag "sonarsource/sonarqube:scanner-${{ steps.get_version.outputs.buildnumber }}" "sonarsource/sonar-scanner-cli:${{ steps.get_version.outputs.full_image_tag }}"
           docker tag "sonarsource/sonarqube:scanner-${{ steps.get_version.outputs.buildnumber }}" "repox-sonarsource-docker-releases.jfrog.io/sonarsource/sonar-scanner-cli:${{ steps.get_version.outputs.full_image_tag }}"
-      - name: Setup BATS
-        uses: mig4/setup-bats@v1
-        with:
-          bats-version: 1.2.1
-      - name: Test image
-        run: |
-          echo "Running tests on image"
-          TEST_IMAGE="sonarsource/sonar-scanner-cli:${{ steps.get_version.outputs.full_image_tag }}" bats --tap test
       - name: Generate CycloneDX SBOM
         uses: SonarSource/gh-action_sbom@v1
         with:
@@ -74,7 +66,7 @@ jobs:
         env:
           GPG_PRIVATE_KEY_PASSPHRASE: ${{ fromJSON(steps.secrets.outputs.vault).gpg_passphrase }}
           GPG_PRIVATE_KEY_BASE64: ${{ fromJSON(steps.secrets.outputs.vault).gpg_key }}
-      - name: Push image
+      - name: Push image to Docker Hub and Repox releases
         run: |
           docker login --username ${{ fromJSON(steps.secrets.outputs.vault).docker_username }} --password-stdin <<< "${{ fromJSON(steps.secrets.outputs.vault).docker_access_token }}"
           docker push sonarsource/sonar-scanner-cli:${{ steps.get_version.outputs.major_version }}


### PR DESCRIPTION
Since we are not rebuilding the image but simply "promoting" it, testing during the release workflow seems like a waste of time (and carries a risk of false positives).
This is more consistent with our "build once" principle.