### PR TITLE
Allow default entrypoint to add certificates

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -22,6 +22,7 @@ RUN set -eux; \
     adduser -S -D -u 1000 -G scanner-cli scanner-cli; \
     apk add --no-cache --virtual build-dependencies wget unzip gnupg; \
     apk add --no-cache git bash shellcheck "nodejs>=18" openjdk17-jre musl-locales musl-locales-lang tar; \
+    chmod -R 666 /etc/ssl/certs/java/cacerts; \
     wget -U "scannercli" -q -O /opt/sonar-scanner-cli.zip https://binaries.sonarsource.com/Distribution/sonar-scanner-cli/sonar-scanner-cli-${SONAR_SCANNER_VERSION}.zip; \
     wget -U "scannercli" -q -O /opt/sonar-scanner-cli.zip.asc https://binaries.sonarsource.com/Distribution/sonar-scanner-cli/sonar-scanner-cli-${SONAR_SCANNER_VERSION}.zip.asc; \
     for server in $(shuf -e hkps://keys.openpgp.org \

--- a/bin/entrypoint.sh
+++ b/bin/entrypoint.sh
@@ -16,7 +16,7 @@ if [[ -d /tmp/cacerts ]]; then
   if [[ -n "$(ls -A /tmp/cacerts 2>/dev/null)" ]]; then
     for f in /tmp/cacerts/*
     do
-      keytool -importcert -file "${f}" -alias "$(basename "${f}")" -keystore /usr/lib/jvm/default-jvm/jre/lib/security/cacerts -storepass changeit -trustcacerts -noprompt
+      keytool -importcert -file "${f}" -alias "$(basename "${f}")" -keystore /etc/ssl/certs/java/cacerts -storepass changeit -trustcacerts -noprompt
     done
   fi
 fi


### PR DESCRIPTION
When running the docker container, the regular user "scanner-cli" is used. To allow interaction with the SonarQube service running with a non-public CA certificate, the file needs to be writable by this user.

Regression was introduced in 11e6606 when moving to alpine:3.19.

Please be aware that we are not actively looking for feature contributions. The truth is that it's extremely difficult for someone outside SonarSource to comply with our roadmap and expectations. Therefore, we typically only accept minor cosmetic changes and typo fixes. If you would like to see a new feature, please create a new thread in the forum ["Suggest new features"](https://community.sonarsource.com/c/suggestions/features).

Don't know if this can be considered as part of [SCANDOCKER-12](https://sonarsource.atlassian.net/browse/SCANDOCKER-12). Please let me know if you want me to add that to the commit message.

[SCANDOCKER-12]: https://sonarsource.atlassian.net/browse/SCANDOCKER-12?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

Contributed by STMicroelectronics