### PR TITLE
SCANDOCKER-44 Add tar package to the image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -46,6 +46,7 @@ COPY --from=builder /opt/sonar-scanner /opt/sonar-scanner
 
 RUN \
     dnf install -y git \
+    && dnf install -y tar \
     && dnf install -y nodejs \
     && dnf clean all \
     && set -eux \


### PR DESCRIPTION
The **latest** version of the Docker image no longer contains the `tar` package, as the base image has been switched to Amazon Linux. This change causes the `attach-workspace` job (the default job) to fail in CircleCI.

```bash
Digest: sha256:605ea9a44a12ec328ad59a9b98c740cf0672a467b57ba2ae63cb85cc5831287e
Status: Downloaded newer image for sonarsource/sonar-scanner-cli:latest
sonarsource/sonar-scanner-cli:latest:
  pull stats: download 319.4MiB in 3.233s (98.79MiB/s), extract 319.3MiB in 5.029s (63.49MiB/s)
  time to create container: 1.888s
Time to upload agent and config: 357.124075ms
Time to start containers: 310.351851ms

tar utility is not present in this image but it is required. Please install it to have workflow workspace capability.
```

Additionally, we can’t run the image as the root user to install `tar` during runtime and the `sudo` command also is not present in the image.

To address this, this PR installs `tar` in the base image.

Tests:

```bash
docker build -t sonar:test1 . 
[+] Building 47.1s (20/20) FINISHED                                                                                                                                                                                       docker:desktop-linux
 => [internal] load build definition from Dockerfile                                                                                                                                                                                      0.0s
 => => transferring dockerfile: 2.63kB                                                                                                                                                                                                    0.0s
 => [internal] load metadata for docker.io/library/amazoncorretto:17-al2023                                                                                                                                                               0.0s
 => [internal] load metadata for docker.io/library/alpine:3.19                                                                                                                                                                            2.0s
 => [auth] library/alpine:pull token for registry-1.docker.io                                                                                                                                                                             0.0s
 => [internal] load .dockerignore                                                                                                                                                                                                         0.0s
 => => transferring context: 2B                                                                                                                                                                                                           0.0s
 => [builder 1/5] FROM docker.io/library/alpine:3.19@sha256:ae65dbf8749a7d4527648ccee1fa3deb6bfcae34cbc30fc67aa45c44dcaa90ee                                                                                                              0.4s
 => => resolve docker.io/library/alpine:3.19@sha256:ae65dbf8749a7d4527648ccee1fa3deb6bfcae34cbc30fc67aa45c44dcaa90ee                                                                                                                      0.0s
 => => sha256:188a7166e45935ced07634efdc8e63c13f5f7673b60b051b353475ee00e28fe0 3.36MB / 3.36MB                                                                                                                                            0.4s
 => => extracting sha256:188a7166e45935ced07634efdc8e63c13f5f7673b60b051b353475ee00e28fe0                                                                                                                                                 0.1s
 => [builder 4/5] ADD https://binaries.sonarsource.com/Distribution/sonar-scanner-cli/sonar-scanner-cli-6.2.0.4584.zip.asc /opt/sonar-scanner-cli.zip.asc                                                                                 0.4s
 => [builder 3/5] ADD https://binaries.sonarsource.com/Distribution/sonar-scanner-cli/sonar-scanner-cli-6.2.0.4584.zip /opt/sonar-scanner-cli.zip                                                                                         1.0s
 => [internal] load build context                                                                                                                                                                                                         0.0s
 => => transferring context: 1.91kB                                                                                                                                                                                                       0.0s
 => [scanner-cli-base 1/5] FROM docker.io/library/amazoncorretto:17-al2023@sha256:4836094278985817d7a56547f241a44024f5e3a9efac31ae7b92ee674ec0346b                                                                                        1.1s
 => => resolve docker.io/library/amazoncorretto:17-al2023@sha256:4836094278985817d7a56547f241a44024f5e3a9efac31ae7b92ee674ec0346b                                                                                                         1.0s
 => [auth] library/amazoncorretto:pull token for registry-1.docker.io                                                                                                                                                                     0.0s
 => [builder 2/5] WORKDIR /opt                                                                                                                                                                                                            0.0s
 => [builder 3/5] ADD https://binaries.sonarsource.com/Distribution/sonar-scanner-cli/sonar-scanner-cli-6.2.0.4584.zip /opt/sonar-scanner-cli.zip                                                                                         0.0s
 => [builder 4/5] ADD https://binaries.sonarsource.com/Distribution/sonar-scanner-cli/sonar-scanner-cli-6.2.0.4584.zip.asc /opt/sonar-scanner-cli.zip.asc                                                                                 0.0s
 => [builder 5/5] RUN set -eux;     apk add --no-cache --virtual build-dependencies gnupg unzip wget;     for server in $(shuf -e hkps://keys.openpgp.org                             hkps://keyserver.ubuntu.com) ; do         gpg --ba  5.8s
 => [scanner-cli-base 2/5] COPY --from=builder /opt/sonar-scanner /opt/sonar-scanner                                                                                                                                                      0.0s
 => [scanner-cli-base 3/5] RUN     dnf install -y git     && dnf install -y tar     && dnf install -y nodejs     && dnf clean all     && set -eux     && groupadd --system --gid 1000 scanner-cli     && useradd --system --uid 1000 --  25.7s
 => [scanner-cli-base 4/5] COPY --chown=scanner-cli:scanner-cli bin /usr/bin/                                                                                                                                                             0.1s
 => [scanner-cli-base 5/5] WORKDIR /usr/src                                                                                                                                                                                               0.0s
 => exporting to image                                                                                                                                                                                                                   12.4s
 => => exporting layers                                                                                                                                                                                                                  10.2s
 => => exporting manifest sha256:02919fd1951c24d6a244bf6f4858ed90d29d4ec780319a61178b15920d3248d7                                                                                                                                         0.0s
 => => exporting config sha256:04e49abdaa06adcf9d1ea671f7c3d958c814ff9072b1da945d7b3d989180ae68                                                                                                                                           0.0s
 => => exporting attestation manifest sha256:7e40f23a6f96624b3e80c7aef9e376b267332e7ccb82e13209b91838f9d8c92a                                                                                                                             0.0s
 => => exporting manifest list sha256:ce2409b9233c583254c7544a81fba60e5b0f093debba8a2e77f53f69f7bc3d5f                                                                                                                                    0.0s
 => => naming to docker.io/library/sonar:test1                                                                                                                                                                                            0.0s
 => => unpacking to docker.io/library/sonar:test1                                                                                                                                                                                         2.1s

docker run -it  sonar:test1 bash

bash-5.2$ tar
tar: You must specify one of the '-Acdtrux', '--delete' or '--test-label' options
Try 'tar --help' or 'tar --usage' for more information.
bash-5.2$ %
```                                                                               