### PR TITLE
SCANDOCKER-43 Update embedded Scanner CLI to 6.2.1

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -3,7 +3,7 @@ FROM alpine:3.19 AS builder
 LABEL org.opencontainers.image.url=https://github.com/SonarSource/sonar-scanner-cli-docker
 
 ARG SONAR_SCANNER_HOME=/opt/sonar-scanner
-ARG SONAR_SCANNER_VERSION=6.2.0.4584
+ARG SONAR_SCANNER_VERSION=6.2.1.4610
 ENV HOME=/tmp \
     XDG_CONFIG_HOME=/tmp \
     SONAR_SCANNER_HOME=${SONAR_SCANNER_HOME} \


### PR DESCRIPTION
Minor update of the scanner CLI to simplify SSL configuration for SonarQube < 10.6