### PR TITLE
Ensure Mend project name is stable

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -26,7 +26,7 @@ vm_instance_template: &VM_TEMPLATE
   memory: 16G
 
 only_sonarsource_qa: &ONLY_SONARSOURCE_QA
-  only_if: $CIRRUS_USER_COLLABORATOR == 'true' && $CIRRUS_TAG == "" && ($CIRRUS_PR != "" || $CIRRUS_BRANCH == $CIRRUS_DEFAULT_BRANCH || $CIRRUS_BRANCH =~ "branch-.*" || $CIRRUS_BUILD_SOURCE == 'api' )
+  only_if: $CIRRUS_CRON == "" && $CIRRUS_USER_COLLABORATOR == 'true' && $CIRRUS_TAG == "" && ($CIRRUS_PR != "" || $CIRRUS_BRANCH == $CIRRUS_DEFAULT_BRANCH || $CIRRUS_BRANCH =~ "branch-.*" || $CIRRUS_BUILD_SOURCE == 'api' )
 
 build_task:
   <<: *ONLY_SONARSOURCE_QA
@@ -41,7 +41,7 @@ build_task:
 # Scan the current image built and pushed to Artifactory
 mend_task:
   # run only on default and long-term branches
-  only_if: $CIRRUS_USER_COLLABORATOR == 'true' && $CIRRUS_TAG == "" && ($CIRRUS_BRANCH == $CIRRUS_DEFAULT_BRANCH || $CIRRUS_BRANCH =~ "branch-.*")
+  only_if: $CIRRUS_CRON == "" && $CIRRUS_USER_COLLABORATOR == 'true' && $CIRRUS_TAG == "" && ($CIRRUS_BRANCH == $CIRRUS_DEFAULT_BRANCH || $CIRRUS_BRANCH =~ "branch-.*")
   ec2_instance:
     <<: *VM_TEMPLATE
   login_script:
@@ -50,30 +50,31 @@ mend_task:
     - apt-get remove -y unattended-upgrades
     - apt-get update && apt-get install -y --no-install-recommends openjdk-17-jre
     - curl -sSL https://unified-agent.s3.amazonaws.com/wss-unified-agent.jar -o wss-unified-agent.jar
-    - echo "docker.includes=.*${DOCKER_IMAGE}.*" >> .cirrus/wss-unified-agent.config
-  scan_script:
-    - echo "Scan the ${STAGING_IMAGE_TAG} image"
+    - echo "docker.includes=.*${CIRRUS_BRANCH}.*" >> .cirrus/wss-unified-agent.config
+  pull_script:
     - docker pull "${STAGING_IMAGE_TAG}"
-    - java -jar wss-unified-agent.jar -c .cirrus/wss-unified-agent.config -apiKey $MEND_API_KEY -project ${DOCKER_IMAGE}:${CIRRUS_BRANCH}
+  mend_scan_script:
+    # Retag the image to have a clean project name on Mend
+    - docker tag "${STAGING_IMAGE_TAG}" "${DOCKER_IMAGE}:${CIRRUS_BRANCH}"
+    - java -jar wss-unified-agent.jar -c .cirrus/wss-unified-agent.config -apiKey $MEND_API_KEY
   depends_on: build
 
 # Scan the latest image published on Docker Hub
 latest_mend_task:
   only_if: $CIRRUS_CRON == 'nightly-mend-scan'
-  env:
-    PUBLIC_IMAGE_NAME: sonarsource/sonar-scanner-cli
-    TAG: latest
   ec2_instance:
     <<: *VM_TEMPLATE
   setup_script:
     - apt-get remove -y unattended-upgrades
     - apt-get update && apt-get install -y --no-install-recommends openjdk-17-jre
     - curl -sSL https://unified-agent.s3.amazonaws.com/wss-unified-agent.jar -o wss-unified-agent.jar
-    - echo "docker.includes=.*${PUBLIC_IMAGE_NAME}.*" >> .cirrus/wss-unified-agent.config
-  scan_script:
-    - echo "Scan the ${PUBLIC_IMAGE_NAME}:${TAG} image"
-    - docker pull "${PUBLIC_IMAGE_NAME}:${TAG}"
-    - java -jar wss-unified-agent.jar -c .cirrus/wss-unified-agent.config -apiKey $MEND_API_KEY -project ${PUBLIC_IMAGE_NAME}:${TAG}
+    - echo "docker.includes=.*latest-from-docker-hub.*" >> .cirrus/wss-unified-agent.config
+  pull_script:
+    - docker pull "${DOCKER_IMAGE}:latest"
+  mend_scan_script:
+    # Retag the image to have a clean project name on Mend
+    - docker tag "${DOCKER_IMAGE}:latest" "${DOCKER_IMAGE}:latest-from-docker-hub"
+    - java -jar wss-unified-agent.jar -c .cirrus/wss-unified-agent.config -apiKey $MEND_API_KEY
 
 test_docker_builder:
   <<: *ONLY_SONARSOURCE_QA

--- a/.cirrus/wss-unified-agent.config
+++ b/.cirrus/wss-unified-agent.config
@@ -2,3 +2,4 @@ excludes=**/opt/sonar-scanner/**/*
 docker.scanImages=true
 wss.url=https://saas-eu.whitesourcesoftware.com/agent
 productName=Scanner/CliDocker
+docker.projectNameFormat=repositoryNameAndTag


### PR DESCRIPTION
The name of the project in Mend can't be fully chosen. The best we can do to avoid a new project creation for each build, is to use the `projectNameFormat=repositoryNameAndTag`, and retag the image.