### PR TITLE
SCANDOCKER-50 Update QA to use a token

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -80,7 +80,7 @@ test_docker_builder:
   login_script:
     - docker login "${DOCKER_REPOX_BUILDS_REGISTRY}" -u "${ARTIFACTORY_DEPLOY_USERNAME}" --password-stdin <<<"${ARTIFACTORY_DEPLOY_PASSWORD}"
   test_script:
-    - apt-get update && apt-get install -qy bats
+    - apt-get update && apt-get install -qy bats curl jq
     - echo "Checking out the sonar-scanning-examples repository"
     - git clone https://github.com/SonarSource/sonar-scanning-examples.git target_repository
     - echo "Test the ${STAGING_IMAGE_TAG} image"


### PR DESCRIPTION
[SCANDOCKER-50](https://sonarsource.atlassian.net/browse/SCANDOCKER-50)

username/password support had been removed in the latest SonarQube releases


[SCANDOCKER-50]: https://sonarsource.atlassian.net/browse/SCANDOCKER-50?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ