### PR TITLE
Add ARM64 (linux/arm64) multi-architecture Docker image support

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -52,6 +52,12 @@ jobs:
           username: ${{ fromJSON(steps.secrets.outputs.vault).ARTIFACTORY_DEPLOY_USERNAME }}
           password: ${{ fromJSON(steps.secrets.outputs.vault).ARTIFACTORY_DEPLOY_PASSWORD }}
 
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@29109295f81e9208d7d86ff1c6c12d2833863392  # v3.6.0
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@b5ca514318bd6ebac0fb2aedd5d36ec1b5c232a2  # v3.10.0
+
       - name: Setup Docker image
         shell: bash
         id: docker-image-setup
@@ -64,7 +70,7 @@ jobs:
         env:
           DOCKER_IMAGE_BUILD_NUMBER: ${{ steps.docker-image-setup.outputs.docker-image }}
         run: |
-          docker build --tag "${DOCKER_IMAGE_BUILD_NUMBER}" --push .
+          docker buildx build --platform linux/amd64,linux/arm64 --tag "${DOCKER_IMAGE_BUILD_NUMBER}" --push .
 
   test:
     needs:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -47,9 +47,14 @@ jobs:
         with:
           repository: SonarSource/sonar-scanning-examples
           path: target_repository
+      - name: Docker login to Repox registry
+        uses: docker/login-action@184bdaa0721073962dff0199f1fb9940f07167d1  # v3.5.0
+        with:
+          registry: repox-sonarsource-docker-builds.jfrog.io
+          username: ${{ fromJSON(steps.secrets.outputs.vault).repox_username }}
+          password: ${{ fromJSON(steps.secrets.outputs.vault).repox_access_token }}
       - name: Pull staged image
         run: |
-          docker login repox-sonarsource-docker-builds.jfrog.io --username ${{ fromJSON(steps.secrets.outputs.vault).repox_username }} --password-stdin <<< "${{ fromJSON(steps.secrets.outputs.vault).repox_access_token }}"
           docker pull "repox-sonarsource-docker-builds.jfrog.io/sonarsource/sonar-scanner-cli:${{ steps.get_version.outputs.buildnumber }}"
       - name: Generate CycloneDX SBOM
         uses: SonarSource/gh-action_sbom@v3
@@ -78,21 +83,23 @@ jobs:
           else
             echo "${docker_image}#${full_image_tag} promoted to ${target_repo_key}"
           fi
-      - name: Push image to Docker Hub
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@b5ca514318bd6ebac0fb2aedd5d36ec1b5c232a2  # v3.10.0
+      - name: Docker login to Docker Hub
+        uses: docker/login-action@184bdaa0721073962dff0199f1fb9940f07167d1  # v3.5.0
+        with:
+          username: ${{ fromJSON(steps.secrets.outputs.vault).docker_username }}
+          password: ${{ fromJSON(steps.secrets.outputs.vault).docker_access_token }}
+      - name: Push multi-arch image to Docker Hub
+        env:
+          SOURCE_IMAGE: "repox-sonarsource-docker-builds.jfrog.io/sonarsource/sonar-scanner-cli:${{ steps.get_version.outputs.buildnumber }}"
         run: |
-          buildnumber=${{ steps.get_version.outputs.buildnumber }}
-          
-          docker tag "repox-sonarsource-docker-builds.jfrog.io/sonarsource/sonar-scanner-cli:${buildnumber}" "sonarsource/sonar-scanner-cli:latest"
-          docker tag "repox-sonarsource-docker-builds.jfrog.io/sonarsource/sonar-scanner-cli:${buildnumber}" "sonarsource/sonar-scanner-cli:${{ steps.get_version.outputs.major_version }}"
-          docker tag "repox-sonarsource-docker-builds.jfrog.io/sonarsource/sonar-scanner-cli:${buildnumber}" "sonarsource/sonar-scanner-cli:${{ steps.get_version.outputs.major_minor }}"
-          docker tag "repox-sonarsource-docker-builds.jfrog.io/sonarsource/sonar-scanner-cli:${buildnumber}" "sonarsource/sonar-scanner-cli:${{ steps.get_version.outputs.full_image_tag }}"
-
-          docker login --username ${{ fromJSON(steps.secrets.outputs.vault).docker_username }} --password-stdin <<< "${{ fromJSON(steps.secrets.outputs.vault).docker_access_token }}"
-
-          docker push sonarsource/sonar-scanner-cli:latest
-          docker push sonarsource/sonar-scanner-cli:${{ steps.get_version.outputs.major_version }}
-          docker push sonarsource/sonar-scanner-cli:${{ steps.get_version.outputs.major_minor }}
-          docker push sonarsource/sonar-scanner-cli:${{ steps.get_version.outputs.full_image_tag }}
+          docker buildx imagetools create \
+            --tag "sonarsource/sonar-scanner-cli:latest" \
+            --tag "sonarsource/sonar-scanner-cli:${{ steps.get_version.outputs.major_version }}" \
+            --tag "sonarsource/sonar-scanner-cli:${{ steps.get_version.outputs.major_minor }}" \
+            --tag "sonarsource/sonar-scanner-cli:${{ steps.get_version.outputs.full_image_tag }}" \
+            "${SOURCE_IMAGE}"
       - name: Notify success on Slack
         uses: slackapi/slack-github-action@v2.0.0
         with:


### PR DESCRIPTION
## Summary

- Re-enable ARM64 support using Docker Buildx and QEMU in the GitHub Actions CI pipeline
- Build workflow now produces a multi-arch manifest covering `linux/amd64` and `linux/arm64`
- Release workflow uses `docker buildx imagetools create` to promote the full multi-arch manifest to Docker Hub, replacing the single-platform `docker tag`/`docker push` approach

## Context

ARM64 support was previously added (Sept 2023) but removed in April 2024 (SCANCLI-141) when CI was on Cirrus CI. Since then, CI has migrated to GitHub Actions, and both base images (`alpine:3.19` and `amazoncorretto:21-al2023`) already support ARM64 natively. The SonarScanner CLI binary (8.0.1.6346) is Java-based and platform-independent, with native ARM64 support in the current stable release.

Users running on AWS Graviton (ARM64) Jenkins nodes or other ARM64 infrastructure currently cannot use the official Docker image — it crashes with `exec format error`.

## Why this works without Dockerfile changes

- **Base images**: `alpine:3.19` and `amazoncorretto:21-al2023` both publish `linux/arm64` variants
- **Scanner CLI 8.0.1.6346**: The latest stable release — Java-based and platform-independent with native ARM64 support. No architecture-specific binaries involved
- **Entrypoint**: Shell script, architecture-agnostic

## Changes

### `.github/workflows/build.yml`
- Added `docker/setup-qemu-action` for cross-platform emulation
- Added `docker/setup-buildx-action` for buildx builder
- Changed `docker build` to `docker buildx build --platform linux/amd64,linux/arm64`

### `.github/workflows/release.yml`
- Added `docker/setup-buildx-action` for buildx builder
- Replaced `docker tag` + `docker push` with `docker buildx imagetools create` to copy the entire multi-arch manifest to Docker Hub
- Used `docker/login-action` for registry authentication (consistent with build workflow)

## Test plan

- [ ] CI build produces a multi-arch manifest with both `linux/amd64` and `linux/arm64`
- [ ] Existing BATS integration tests pass (amd64 variant pulled automatically on amd64 runner)
- [ ] `docker manifest inspect` shows both architectures in the image index
- [ ] Release workflow successfully promotes multi-arch manifest to Docker Hub

🤖 Generated with [Claude Code](https://claude.com/claude-code)