### PR TITLE
SCANDOCKER-74 Add ARM64 (linux/arm64) multi-architecture Docker image support

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -52,6 +52,12 @@ jobs:
           username: ${{ fromJSON(steps.secrets.outputs.vault).ARTIFACTORY_DEPLOY_USERNAME }}
           password: ${{ fromJSON(steps.secrets.outputs.vault).ARTIFACTORY_DEPLOY_PASSWORD }}
 
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@29109295f81e9208d7d86ff1c6c12d2833863392  # v3.6.0
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@b5ca514318bd6ebac0fb2aedd5d36ec1b5c232a2  # v3.10.0
+
       - name: Setup Docker image
         shell: bash
         id: docker-image-setup
@@ -64,7 +70,7 @@ jobs:
         env:
           DOCKER_IMAGE_BUILD_NUMBER: ${{ steps.docker-image-setup.outputs.docker-image }}
         run: |
-          docker build --tag "${DOCKER_IMAGE_BUILD_NUMBER}" --push .
+          docker buildx build --platform linux/amd64,linux/arm64 --tag "${DOCKER_IMAGE_BUILD_NUMBER}" --push .
 
   test:
     needs:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -47,9 +47,14 @@ jobs:
         with:
           repository: SonarSource/sonar-scanning-examples
           path: target_repository
+      - name: Docker login to Repox registry
+        uses: docker/login-action@184bdaa0721073962dff0199f1fb9940f07167d1  # v3.5.0
+        with:
+          registry: repox-sonarsource-docker-builds.jfrog.io
+          username: ${{ fromJSON(steps.secrets.outputs.vault).repox_username }}
+          password: ${{ fromJSON(steps.secrets.outputs.vault).repox_access_token }}
       - name: Pull staged image
         run: |
-          docker login repox-sonarsource-docker-builds.jfrog.io --username ${{ fromJSON(steps.secrets.outputs.vault).repox_username }} --password-stdin <<< "${{ fromJSON(steps.secrets.outputs.vault).repox_access_token }}"
           docker pull "repox-sonarsource-docker-builds.jfrog.io/sonarsource/sonar-scanner-cli:${{ steps.get_version.outputs.buildnumber }}"
       - name: Generate CycloneDX SBOM
         uses: SonarSource/gh-action_sbom@v3
@@ -78,21 +83,23 @@ jobs:
           else
             echo "${docker_image}#${full_image_tag} promoted to ${target_repo_key}"
           fi
-      - name: Push image to Docker Hub
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@b5ca514318bd6ebac0fb2aedd5d36ec1b5c232a2  # v3.10.0
+      - name: Docker login to Docker Hub
+        uses: docker/login-action@184bdaa0721073962dff0199f1fb9940f07167d1  # v3.5.0
+        with:
+          username: ${{ fromJSON(steps.secrets.outputs.vault).docker_username }}
+          password: ${{ fromJSON(steps.secrets.outputs.vault).docker_access_token }}
+      - name: Push multi-arch image to Docker Hub
+        env:
+          SOURCE_IMAGE: "repox-sonarsource-docker-builds.jfrog.io/sonarsource/sonar-scanner-cli:${{ steps.get_version.outputs.buildnumber }}"
         run: |
-          buildnumber=${{ steps.get_version.outputs.buildnumber }}
-          
-          docker tag "repox-sonarsource-docker-builds.jfrog.io/sonarsource/sonar-scanner-cli:${buildnumber}" "sonarsource/sonar-scanner-cli:latest"
-          docker tag "repox-sonarsource-docker-builds.jfrog.io/sonarsource/sonar-scanner-cli:${buildnumber}" "sonarsource/sonar-scanner-cli:${{ steps.get_version.outputs.major_version }}"
-          docker tag "repox-sonarsource-docker-builds.jfrog.io/sonarsource/sonar-scanner-cli:${buildnumber}" "sonarsource/sonar-scanner-cli:${{ steps.get_version.outputs.major_minor }}"
-          docker tag "repox-sonarsource-docker-builds.jfrog.io/sonarsource/sonar-scanner-cli:${buildnumber}" "sonarsource/sonar-scanner-cli:${{ steps.get_version.outputs.full_image_tag }}"
-
-          docker login --username ${{ fromJSON(steps.secrets.outputs.vault).docker_username }} --password-stdin <<< "${{ fromJSON(steps.secrets.outputs.vault).docker_access_token }}"
-
-          docker push sonarsource/sonar-scanner-cli:latest
-          docker push sonarsource/sonar-scanner-cli:${{ steps.get_version.outputs.major_version }}
-          docker push sonarsource/sonar-scanner-cli:${{ steps.get_version.outputs.major_minor }}
-          docker push sonarsource/sonar-scanner-cli:${{ steps.get_version.outputs.full_image_tag }}
+          docker buildx imagetools create \
+            --tag "sonarsource/sonar-scanner-cli:latest" \
+            --tag "sonarsource/sonar-scanner-cli:${{ steps.get_version.outputs.major_version }}" \
+            --tag "sonarsource/sonar-scanner-cli:${{ steps.get_version.outputs.major_minor }}" \
+            --tag "sonarsource/sonar-scanner-cli:${{ steps.get_version.outputs.full_image_tag }}" \
+            "${SOURCE_IMAGE}"
       - name: Notify success on Slack
         uses: slackapi/slack-github-action@v2.0.0
         with:


### PR DESCRIPTION
This PR is a copy of https://github.com/SonarSource/sonar-scanner-cli-docker/pull/306 as external pull requests cannot run the CI/CD. 

Re-enables ARM64 support using Docker Buildx and QEMU in the GitHub Actions pipeline. The build workflow now produces a multi-arch manifest covering linux/amd64 and linux/arm64. The release workflow uses `docker buildx imagetools create` to promote the full multi-arch manifest to Docker Hub instead of single-platform docker tag/push.

<!-- 
  Only for standalone PRs without Jira issue in the PR title: 
    * Replace this comment with Epic ID to create a new Task in Jira
    * Replace this comment with Issue ID to create a new Sub-Task in Jira
    * Ignore or delete this note to create a new Task in Jira without a parent 
-->

Please be aware that we are not actively looking for feature contributions. The truth is that it's extremely difficult for someone outside SonarSource to comply with our roadmap and expectations. Therefore, we typically only accept minor cosmetic changes and typo fixes. If you would like to see a new feature, please create a new thread in the forum ["Suggest new features"](https://community.sonarsource.com/c/suggestions/features).

With that in mind, if you would like to submit a code contribution, make sure that you adhere to the following guidelines and all tests are passing:

- [ ] Please explain your motives to contribute this change: what problem you are trying to fix, what improvement you are trying to make
- [ ] Use the following formatting style: [SonarSource/sonar-developer-toolset](https://github.com/SonarSource/sonar-developer-toolset#code-style)
- [ ] If there is a [JIRA](http://jira.sonarsource.com/browse/SQSCANNER) ticket available, please make your commits and pull request start with the ticket ID (SQSCANNER-XXXX)

We will try to give you feedback on your contribution as quickly as possible.

Thank You!
The SonarSource Team
