### PR TITLE
SCANDOCKER-79 Change Code Owners and Slack notification

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,1 +1,3 @@
-.github/CODEOWNERS @sonarsource/quality-processing-squad
+# https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/customizing-your-repository/about-code-owners
+
+* @sonarsource/code-quality-ci-experience-squad

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -124,7 +124,7 @@ jobs:
           webhook-type: incoming-webhook
           payload: |
             {
-              "channel": "ops-analysis-experience",
+              "channel": "ops-ci-experience",
               "attachments": [
                 {
                   "color": "#00ff00",
@@ -140,7 +140,7 @@ jobs:
           webhook-type: incoming-webhook
           payload: |
             {
-              "channel": "ops-analysis-experience",
+              "channel": "ops-ci-experience",
               "attachments": [
                 {
                   "color": "#ff0000",


### PR DESCRIPTION
----
## Summary by Gitar

- **Repository configuration:**
  - Updated `.github/CODEOWNERS` to assign ownership to `@sonarsource/code-quality-ci-experience-squad`.
- **Slack notifications:**
  - Updated `.github/workflows/release.yml` to route alerts to the `#ops-ci-experience` Slack channel.

<sub>This will update automatically on new commits.</sub>